### PR TITLE
Fix: replace utf-8.decode with hex.decode

### DIFF
--- a/lib/features/verification/logic/SignatureVerificationService.dart
+++ b/lib/features/verification/logic/SignatureVerificationService.dart
@@ -42,7 +42,7 @@ c6/L8XzUYEsocCbc/JHiByGjuB3G9cSU2vUi1HUy5LsCtX2wlHSEObGVBw==
     ECSignature convertedSig = loadAndConvertSignature(sig);
     final ECDSASigner signer = ECDSASigner();
     signer.init(false, PublicKeyParameter<ECPublicKey>(pubKey));
-    Uint8List messageAsBytes = Uint8List.fromList(utf8.encode(hash));
+    Uint8List messageAsBytes = Uint8List.fromList(hex.decode(hash));
     return signer.verifySignature(messageAsBytes, convertedSig);
   }
 }

--- a/test/logic/signatureValidation_test.dart
+++ b/test/logic/signatureValidation_test.dart
@@ -13,7 +13,8 @@ void main() {
   group("Signature validation", () {
     late final ISignatureVerificationService verificationService;
     late final AsymmetricKeyPair<PublicKey, PrivateKey> keyPair;
-    const String message = "Test message";
+    const String message =
+        "8b89d2ab5300a30edb573a8da671a9438cdcccbc42f2a153927e8ba8f54d611c";
 
     setUp(() {
       verificationService = SignatureVerificationService();
@@ -23,7 +24,7 @@ void main() {
     test("should return false if a different privKey is used to sign a message",
         () {
       final signature = CryptoUtils.ecSign(keyPair.privateKey as ECPrivateKey,
-          Uint8List.fromList(utf8.encode(message)),
+          Uint8List.fromList(hex.decode(message)),
           algorithmName: "SHA-256/ECDSA");
       final encoded = ASN1Sequence(elements: [
         ASN1Integer(signature.r),


### PR DESCRIPTION
Explanation: To allow cross Platform signature verification `utf8.encode` is replaced with `hex.decode` this will also resolve the truncation.