### PR TITLE
Fix notification issue

### DIFF
--- a/assets/translations/ar.json
+++ b/assets/translations/ar.json
@@ -78,6 +78,7 @@
     },
     "verificationNotification": {
         "title": "جارٍ التحقق",
-        "validatingMetaData": "التحقق من صحة البيانات الوصفية"
+        "validatingMetaData": "التحقق من صحة البيانات الوصفية",
+        "hashing": "يتم حساب قيمة التجزئة"
     }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,5 +1,6 @@
-// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: non_constant_identifier_names, constant_identifier_names
 
+import 'dart:ui';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 final String GET_KEY_URL = dotenv.env["GET_KEY_URL"] ?? "";
@@ -7,6 +8,14 @@ final String CHECK_KEY_URL = dotenv.env["CHECK_KEY_URL"] ?? "";
 final String SIGN_URL = dotenv.env["SIGN_URL"] ?? "";
 final String VERIFY_URL = dotenv.env["VERIFY_URL"] ?? "";
 final String SENTRY_DSN = dotenv.env["SENTRY_DSN"] ?? "";
+const List<Locale> SUPPORTED_LOCALS = [
+  Locale("en"),
+  Locale("de"),
+  Locale("sn"),
+  Locale("fr"),
+  Locale("jp"),
+  Locale("zn"),
+  Locale("ar")
+];
 
-// ignore: constant_identifier_names
 const String WIKI_URL = "https://github.com/Flajt/decentproof-app/wiki/FAQ";

--- a/lib/features/hashing/bloc/PreparationBloc/PreparationBloc.dart
+++ b/lib/features/hashing/bloc/PreparationBloc/PreparationBloc.dart
@@ -73,8 +73,8 @@ class PreparationBloc extends Bloc<MetaDataEvents, PreparationState> {
             "instructions", "audio::${event.filePath}");
         await foregroundService.start(
             startPreperationForegroundService,
-            "perperationNotification.title".tr(),
-            "perperationNotification.initialDescription".tr());
+            tr("perperationNotification.title"),
+            tr("perperationNotification.initalDescription"));
         ReceivePort port = await foregroundService.getReceivePort();
         final stream = port.asBroadcastStream();
         await emit.forEach(stream, onData: (message) {
@@ -122,10 +122,11 @@ class PreparationBloc extends Bloc<MetaDataEvents, PreparationState> {
       try {
         final path = await imageSavingService.saveFile();
         await foregroundService.setData("instructions", "image::$path");
-        await foregroundService.start(
-            startPreperationForegroundService,
-            "perperationNotification.title".tr(),
-            "perperationNotification.initialDescription".tr());
+        final notificationTitle = tr("perperationNotification.title");
+        final notificationBody =
+            tr("perperationNotification.initalDescription");
+        await foregroundService.start(startPreperationForegroundService,
+            notificationTitle, notificationBody);
         ReceivePort port = await foregroundService.getReceivePort();
         final stream = port.asBroadcastStream();
         await emit.forEach(stream, onData: (message) {
@@ -177,8 +178,8 @@ class PreparationBloc extends Bloc<MetaDataEvents, PreparationState> {
         await foregroundService.setData("instructions", "video::$path");
         await foregroundService.start(
             startPreperationForegroundService,
-            "perperationNotification.title".tr(),
-            "perperationNotification.initialDescription".tr());
+            tr("perperationNotification.title"),
+            tr("perperationNotification.initalDescription"));
         ReceivePort port = await foregroundService.getReceivePort();
         final stream = port.asBroadcastStream();
         await emit.forEach(stream, onData: (message) {

--- a/lib/features/hashing/logic/foregroundService/PerperationTaskHandler.dart
+++ b/lib/features/hashing/logic/foregroundService/PerperationTaskHandler.dart
@@ -10,7 +10,7 @@ import 'package:decentproof/features/metadata/interfaces/IMetaDataService.dart';
 import 'package:decentproof/features/metadata/models/LocationModel.dart';
 import 'package:decentproof/shared/util/initSentry.dart';
 import 'package:decentproof/shared/util/register.dart';
-import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:get_it/get_it.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -21,7 +21,7 @@ class PreperationTaskHandler extends TaskHandler {
   void onStart(DateTime timestamp, SendPort? sendPort) async {
     DartPluginRegistrant.ensureInitialized();
     try {
-      await EasyLocalization.ensureInitialized();
+      await dotenv.load();
       await initSentry();
       await registar();
       final getIt = GetIt.I;
@@ -173,7 +173,6 @@ class PreperationTaskHandler extends TaskHandler {
     // Note that the app will only route to "/resume-route" when it is exited so
     // it will usually be necessary to send a message through the send port to
     // signal it to restore state when the app is already started.
-    FlutterForegroundTask.launchApp("/");
   }
 
   Future<void> sendAUpdateProgress(SendPort? sendPort, String step,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:decentproof/constants.dart';
 import 'package:decentproof/features/hashing/bloc/SubmissionBloc.dart';
 import 'package:decentproof/features/hashing/bloc/PreparationBloc/PreparationBloc.dart';
 import 'package:decentproof/features/metadata/bloc/LocationWarningBloc.dart';
@@ -44,15 +45,7 @@ void main() async {
         useOnlyLangCode: true,
         fallbackLocale: const Locale("en"),
         path: "assets/translations",
-        supportedLocales: const [
-          Locale("en"),
-          Locale("de"),
-          Locale("sn"),
-          Locale("fr"),
-          Locale("jp"),
-          Locale("zn"),
-          Locale("ar")
-        ],
+        supportedLocales: SUPPORTED_LOCALS,
         child: const MyApp()));
     Bloc.observer = MetricsBlocObserver();
   }, (error, stack) {

--- a/lib/shared/foregroundService/ForegroundServiceWrapper.dart
+++ b/lib/shared/foregroundService/ForegroundServiceWrapper.dart
@@ -10,7 +10,7 @@ class ForegroundServiceWrapper implements IForegroundService {
       androidNotificationOptions: AndroidNotificationOptions(
           channelId: 'decentproof_hashing_service',
           channelName: 'Hashing & Preperation Channel',
-          channelDescription: "notification.description".tr(),
+          channelDescription: "notificationChannel.description".tr(),
           channelImportance: NotificationChannelImportance.LOW,
           priority: NotificationPriority.MAX,
           visibility: NotificationVisibility.VISIBILITY_PRIVATE,

--- a/lib/shared/util/loadTranslations.dart
+++ b/lib/shared/util/loadTranslations.dart
@@ -1,0 +1,34 @@
+import 'dart:ui';
+
+import 'package:decentproof/constants.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/src/easy_localization_controller.dart';
+import 'package:easy_localization/src/localization.dart';
+
+/// Load translations from assets and keep them in memory
+/// Can be used to load translations in foreground services etc
+/// Please also use `final Localization L = Localization.instance;` in the foreground service with `L.tr("my.key")`
+/// See: https://github.com/aissat/easy_localization/issues/210#issuecomment-806089855
+Future<void> loadTranslations() async {
+  //this will only set EasyLocalizationController.savedLocale
+  await EasyLocalizationController.initEasyLocation();
+
+  final controller = EasyLocalizationController(
+    saveLocale: true, //mandatory to use EasyLocalizationController.savedLocale
+    fallbackLocale: const Locale('en'),
+    supportedLocales: SUPPORTED_LOCALS,
+    assetLoader: const RootBundleAssetLoader(),
+    useOnlyLangCode: true,
+    useFallbackTranslations: true,
+    path: "assets/translations",
+    onLoadError: (e) {},
+  );
+
+  //Load translations from assets
+  await controller.loadTranslations();
+
+  //load translations into exploitable data, kept in memory
+  Localization.load(controller.locale,
+      translations: controller.translations,
+      fallbackTranslations: controller.fallbackTranslations);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.3.1+15
+version: 2.3.2+16
 
 environment:
   sdk: ">=3.0.5 <4.0.0"

--- a/test/consts_test.dart
+++ b/test/consts_test.dart
@@ -1,0 +1,33 @@
+import "package:decentproof/constants.dart";
+import "package:flutter_dotenv/flutter_dotenv.dart";
+import "package:test/test.dart";
+
+// While it seems senseless at first, this is to figure out if the env vars can be accessed in the CI/CD pipeline.
+void main() {
+  setUp(() async {
+    await dotenv.load(fileName: ".env");
+  });
+  group(
+    "Constants",
+    () {
+      test("SENTRY_DSN is not empty", () {
+        expect(SENTRY_DSN, isNotEmpty);
+      });
+      test("SIGN_URL is not empty", () {
+        expect(SIGN_URL, isNotEmpty);
+      });
+      test("VERIFY_URL is not empty", () {
+        expect(VERIFY_URL, isNotEmpty);
+      });
+      test("GET_KEY_URL is not empty", () {
+        expect(GET_KEY_URL, isNotEmpty);
+      });
+      test("CHECK_KEY_URL is not empty", () {
+        expect(CHECK_KEY_URL, isNotEmpty);
+      });
+      test("WIKI_URL is not empty", () {
+        expect(WIKI_URL, isNotEmpty);
+      });
+    },
+  );
+}


### PR DESCRIPTION
- Should resolve issues with missing translations in the foreground notifications from blocs using `tr("my.key")` instead of `"my.key".tr()`
- Might fix missing Sentry DSN issue by calling `dotenv.load` before `initSentry`
- Resolves issue regarding translations in forground notifications directly [#210](https://github.com/aissat/easy_localization/issues/210#issuecomment-806089855)