### PR TITLE
129 detect mock locations

### DIFF
--- a/lib/features/metadata/logic/LocationServiceWrapper.dart
+++ b/lib/features/metadata/logic/LocationServiceWrapper.dart
@@ -30,6 +30,10 @@ class LocationServiceWrapper implements ILocationService {
   Future<LocationModel> requestLocation() async {
     Position locationData = await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.best);
+    if (locationData.isMocked) {
+      throw Exception(
+          'Invalid Location: It seems like you are using a mock location service. Please disable it and try again.');
+    }
     return LocationModel(
         latitude: locationData.latitude, longitude: locationData.longitude);
   }

--- a/test/hashing/bloc/PreparationBloc_test.dart
+++ b/test/hashing/bloc/PreparationBloc_test.dart
@@ -17,8 +17,8 @@ import 'package:test/test.dart';
 
 import '../../mocks.mocks.dart';
 
-/// The whole suit is kinda a mess. Since it's hard to get a good stream of events, I had to use a lot of when().thenAnswer() to simulate the stream of events.
-/// Idealy this wouldn't be the case and we could just hook into a real stream, and do the testing that way.
+/// The whole suit is kinda a mess. Since it's hard to get a good stream of events, the worst thing is that I've got to simulate the stream of events.
+/// Idealy this wouldn't be the case and we could just hook into a real stream, and do the testing that way. Any ideas are appreciated.
 void main() {
   setUp(() async {
     await GetIt.I.reset();


### PR DESCRIPTION
Fix: Use `Postion.isMocked` to check if a position is mocked or not, and throw an error in case it is.
Chore: Add additional test case to `PreperationBloc_test.dart`